### PR TITLE
fix(lint): resolve clippy question_mark lint in get_session

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -60,14 +60,13 @@ impl SessionStore {
         let mut sessions = self.sessions.write().await;
 
         // Check if session exists and is not expired
-        let should_remove = if let Some(session) = sessions.get(session_id) {
+        let should_remove = {
+            let session = sessions.get(session_id)?;
             let session_duration = SystemTime::now()
                 .duration_since(session.last_accessed)
                 .unwrap_or(Duration::ZERO);
 
             session_duration.as_secs() > self.config.session_timeout_seconds
-        } else {
-            return None;
         };
 
         if should_remove {


### PR DESCRIPTION
## Summary
- Unblocks CI on #11 (Dependabot serde_with bump) and any future PR — `cargo clippy -- -D warnings` started failing on unrelated, unchanged code in `src/auth.rs`.
- Root cause: CI uses `dtolnay/rust-toolchain@stable` (unpinned), so a newer clippy release started flagging a `question_mark`-rewritable pattern that an older clippy didn't. `main`'s last scheduled CI run (July 18) was green; this broke silently as `stable` moved forward, with no repo change involved.
- Applies clippy's own suggested rewrite in `get_session` — replaces the `if let ... else { return None }` guard with `?` inside a block. Behavior is unchanged.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 29 unit + 3 integration tests pass, including `test_get_nonexistent_session`, `test_session_timeout`, `test_cleanup_expired_sessions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)